### PR TITLE
Bump Keycloak to 26.2.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       POSTGRES_USER: keycloak
       POSTGRES_PASSWORD: password
   keycloak:
-    image: quay.io/keycloak/keycloak:21.1.1
+    image: quay.io/keycloak/keycloak:26.2.5
     command: '--spi-login-protocol-openid-connect-legacy-logout-redirect-uri=true start --metrics-enabled=true'
     ports:
       - 8085:8080


### PR DESCRIPTION
Compatibility was tested against each major version from 21.1.1 to 26.2.5.

I registered and signed in to a new user on each version, and ensured this account was also usable with every other version tested - no issues were discovered.